### PR TITLE
fix assertion

### DIFF
--- a/sygus.py
+++ b/sygus.py
@@ -247,7 +247,7 @@ def parse_synth_fun(toplevel: 'SyGuS', sexpr):
                                 constants[res] = None
                         else:
                             assert isinstance(res, Production)
-                            assert res.op.out_type == ret_sort, f"production has sort {res.op.out_type}, but non-terminal expects {ret_sort}"
+                            assert res.op.out_type == sort, f"production {res} has sort {res.op.out_type}, but non-terminal {non_term} expects {sort}"
                             productions.append(res)
             nts[non_term] = Nonterminal(non_term, sort, tuple(parameters), tuple(productions), constants)
 


### PR DESCRIPTION
The previous assertion that checked that the production has the right sort used the return sort of the synth-fun statement, thereby failing everytime there is a non-terminal that has a different sort than the return sort.